### PR TITLE
Add "binary" to initial list of base types

### DIFF
--- a/language-reference.asciidoc
+++ b/language-reference.asciidoc
@@ -13,6 +13,7 @@ Base Types
 * +i32+: A 32-bit signed integer
 * +i64+: A 64-bit signed integer
 * +double+: A 64-bit floating point number
+* +binary+: A byte array
 * +string+: Encoding agnostic text or binary string
 
 Note that Thrift does not support unsigned integers because they have no direct


### PR DESCRIPTION
@diwakergupta, perhaps the existing `string` entry was meant to capture this, but I thought adding an explicit entry for `binary` would be helpful here. I'm not wedded to the copy-- If you have a more precise description / definition for this type, please let me know!
